### PR TITLE
Meeting Notes Markdown File

### DIFF
--- a/docs/minutes/minutes.md
+++ b/docs/minutes/minutes.md
@@ -1,0 +1,34 @@
+# Capstone Group 18 – Meeting Notes
+
+## September 22, 2025
+1. Discussed system architecture and overall structure.
+2. Decided to use Electron for the front-end interface.
+3. Will use Draw.io to create flowcharts and UML diagrams.
+4. Question raised: Should the system run as an online/web-based tool or stay local?
+
+## October 1, 2025
+1. Completed the initial Data Flow Diagram (DFD).
+**Next steps / Fixes needed:**
+1. Create and refine Level 0 DFD.
+2. Investigate where a cache system should be implemented.
+3. Consider whether developing a consultation module/software is within project scope.
+**Noted DFD Issues:**
+1. 1.0 File Selection appears twice.
+2. 5.0 Static Website Generation incorrectly loops to a new user instead of the original user.
+
+## October 8, 2025
+**TA Clarification Needed:**
+Do we actually need to use a Database, or can we operate without one given project requirements?
+
+## October 16, 2025
+1. Confirmed project direction and next implementation steps.
+2. Agreed to begin with a CLI prototype to validate the core system workflow.
+3. Plan to test and refine the CLI version before expanding with more advanced features.
+**Added a technical enhancement consideration:**
+1. Implement OS-specific metadata extraction, using Linux/macOS system calls when applicable and Windows-specific functions where necessary.
+2. Reviewed Milestone structure and began outlining task distribution to ensure consistent weekly progress.
+3. Decided to meet in person during Monday class sessions to work collaboratively.
+**Agreed to:**
+1. Create GitHub issues for every task.
+2. Link branches and pull requests to their corresponding issues for traceability and clean workflow.
+3. (Optional) Prepare a mapping document that links each GitHub issue to a specific project requirement for clarity during evaluation/demonstrations.


### PR DESCRIPTION
## 📝 Description

docs: added minutes folder and markdown file for past meeting notes.

This PR introduces a new `minutes/` directory to store meeting documentation and uploads past notes using the established heading format (e.g., ## October 16, 2025). It also sets the structure for consistent future logging and supports ongoing documentation updates.

Type: 📚 Documentation
