### PR TITLE
Issue 82: add list doesnt exist in statisticindex anymore but is still being called

### DIFF
--- a/src/classes/analyzer.py
+++ b/src/classes/analyzer.py
@@ -44,21 +44,21 @@ class BaseFileAnalyzer:
         try:
             metadata = Path(self.filepath).stat()
 
-            created = datetime.datetime.fromtimestamp(
-                getattr(metadata, 'st_birthtime', metadata.st_ctime))
-            last_accessed = datetime.datetime.fromtimestamp(metadata.st_atime)
-            last_modified = datetime.datetime.fromtimestamp(metadata.st_mtime)
-            size_bytes = metadata.st_size
+            # Map file statistic templates to their corresponding timestamp values
+            timestamps = {
+                FileStatCollection.DATE_CREATED.value: getattr(metadata, "st_birthtime", metadata.st_ctime),
+                FileStatCollection.DATE_ACCESSED.value: metadata.st_atime,
+                FileStatCollection.DATE_MODIFIED.value: metadata.st_mtime,
+            }
 
-            stats = [
-                Statistic(FileStatCollection.DATE_CREATED.value, created),
-                Statistic(FileStatCollection.DATE_ACCESSED.value,
-                          last_accessed),
-                Statistic(FileStatCollection.DATE_MODIFIED.value,
-                          last_modified),
-                Statistic(FileStatCollection.FILE_SIZE_BYTES.value, size_bytes)
-            ]
-            self.stats.add_list(stats)
+            # Add timestamp stats
+            for template, value in timestamps.items():
+                self.stats.add(
+                    Statistic(template, datetime.datetime.fromtimestamp(value)))
+
+            self.stats.add(
+                Statistic(FileStatCollection.FILE_SIZE_BYTES.value, metadata.st_size))
+
         except (FileNotFoundError, PermissionError, OSError, AttributeError) as e:
             logging.error(
                 f"Couldn't access metadata for a file in: {self.filepath}. \nError thrown: {str(e)}")


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

The current logic for the `_process` function in the analyzer class uses a function that no longer exists in the `StatsticIndex` class. This PR updates that logic to add statistics to a file report correctly.

Additionally, I refactored the code in the function to make it more readable and concise.

**Closes:** #82

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Tests for this function can be found in `tests/test_analyzer.py`

- [ ] Test A: `test_base_file_analyzer_process_returns_file_report_with_core_stats` -- this tests that the metadata from a file is correctly added to a `FileReport` object and that the variables are of the correct instance (e.g., check that the file's creation date is stored as a `datetime` variable).
- [ ] Test B: `test_base_file_analyzer_nonexistent_file_logs_and_returns_empty` -- this tests that no statistics are returned from the `_process` function for an invalid filepath.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile