### PR TITLE
Handle Inputted Incorrect Filepath Gracefully in CLI

### DIFF
--- a/src/classes/cli.py
+++ b/src/classes/cli.py
@@ -1,6 +1,31 @@
+"""
+This file contains the command line interface (CLI) for the Artifact Miner application.
+"""
 
 import cmd
+import os
 from app import start_miner
+
+
+def _is_valid_filepath_to_zip(filepath: str) -> int:
+    """
+    Helper function to validate the provided filepath.
+    A valid filepath must exist and be a zipped file.
+
+    Int code returns:
+    0 - valid filepath to a zip file
+    1 - invalid filepath
+    2 - filepath does not point to a zip file
+    3 - filepath does not exist
+    """
+
+    if not os.path.exists(filepath):
+        return 3
+    if not os.path.isfile(filepath):
+        return 1
+    if not filepath.endswith('.zip'):
+        return 2
+    return 0
 
 
 class ArtifactMiner(cmd.Cmd):
@@ -67,13 +92,27 @@ class ArtifactMiner(cmd.Cmd):
         '''User specifies the project's filepath'''
         self.update_history(self.cmd_history, "filepath")
 
-        prompt = "Paste or type the full filepath to your project folder: (or 'back'/'cancel' to return): "
-        answer = input(prompt).strip()
+        while True:
+            prompt = "Paste or type the full filepath to your zipped project folder: (or 'back'/'cancel' to return): "
+            answer = input(prompt).strip()
 
-        # Check if user wants to cancel
-        if self._handle_cancel_input(answer):
-            print("\n" + self.options)
-            return  # Return to main menu
+            # Check if user wants to cancel
+            if self._handle_cancel_input(answer):
+                print("\n" + self.options)
+                return  # Return to main menu
+
+            # Validate the filepath
+            error_code = _is_valid_filepath_to_zip(answer)
+            if error_code == 0:
+                break  # Valid filepath found, exit the loop
+            elif error_code == 1:
+                print("\nError: The provided filepath is invalid. Please try again.\n")
+            elif error_code == 2:
+                print(
+                    "\nError: The provided filepath does not point to a zip file. Please try again.\n")
+            elif error_code == 3:
+                print(
+                    "\nError: The provided filepath does not exist. Please try again.\n")
 
         # Process the filepath
         self.project_filepath = answer

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -2,209 +2,281 @@
 Comprehensive tests for the CLI functionality in app.py.
 Tests user interaction flows, command handling, and navigation logic.
 """
-import unittest
+import pytest
 from unittest.mock import patch, mock_open
-import sys
-from src.classes.cli import ArtifactMiner
+from src.classes.cli import ArtifactMiner, _is_valid_filepath_to_zip
 
 
-class TestCLI(unittest.TestCase):
-    """Comprehensive test cases for CLI functionality and user interactions."""
+def test_is_valid_filepath_to_zip(tmp_path):
+    """
+    Tests all error codes for _is_valid_filepath_to_zip function.
+    """
+    # Test case 3: Filepath does not exist
+    non_existent_path = tmp_path / "non_existent.zip"
+    assert _is_valid_filepath_to_zip(str(non_existent_path)) == 3
 
-    def setUp(self):
-        """Set up test fixtures before each test method."""
-        with patch('builtins.print'):  # Suppress initialization output
-            self.cli = ArtifactMiner()
+    # Test case 1: Invalid filepath (not a file)
+    dir_path = tmp_path / "a_directory"
+    dir_path.mkdir()
+    assert _is_valid_filepath_to_zip(str(dir_path)) == 1
 
-    # Initialization and Setup Tests
-    def test_cli_initialization(self):
-        """Test that CLI initializes with correct default values."""
-        self.assertEqual(self.cli.project_filepath, '')
-        self.assertFalse(self.cli.user_consent)
-        self.assertEqual(self.cli.cmd_history, [])
-        self.assertEqual(self.cli.prompt, '(PAF) ')
-        self.assertEqual(self.cli.ruler, '-')
-        self.assertIn("Choose one of the following options", self.cli.options)
-        self.assertIn("Type 'back' or 'cancel'", self.cli.options)
+    # Test case 2: Filepath does not point to a zip file
+    non_zip_file = tmp_path / "file.txt"
+    non_zip_file.write_text("This is a test file.")
+    assert _is_valid_filepath_to_zip(str(non_zip_file)) == 2
 
-    # Command History Management Tests
-    def test_update_history_basic_functionality(self):
-        """Test that command history is properly updated."""
-        self.cli.update_history(self.cli.cmd_history, "perms")
-        self.assertEqual(self.cli.cmd_history, ["perms"])
+    # Test case 0: Valid filepath to a zip file
+    zip_file = tmp_path / "archive.zip"
+    zip_file.write_text("This is a zip file content.")
+    assert _is_valid_filepath_to_zip(str(zip_file)) == 0
 
-        self.cli.update_history(self.cli.cmd_history, "filepath")
-        self.assertEqual(self.cli.cmd_history, ["perms", "filepath"])
 
-    # Cancel Input Handler Tests
-    def test_handle_cancel_input_with_back(self):
-        """Test cancel handler with 'back' command."""
-        self.cli.cmd_history = ["perms"]
+@pytest.fixture
+def cli():
+    """Fixture providing a CLI instance with suppressed initialization output."""
+    with patch('builtins.print'):  # Suppress initialization output
+        return ArtifactMiner()
 
-        with patch('builtins.print') as mock_print:
-            result = self.cli._handle_cancel_input("back")
-            self.assertTrue(result)
-            mock_print.assert_called_with("\nCancelled 'perms' operation.")
-            self.assertEqual(self.cli.cmd_history, [])
+# Initialization and Setup Tests
 
-    def test_handle_cancel_input_with_cancel(self):
-        """Test cancel handler with 'cancel' command."""
-        self.cli.cmd_history = ["filepath"]
 
-        with patch('builtins.print') as mock_print:
-            result = self.cli._handle_cancel_input(
-                "CANCEL")  # Test case insensitive
-            self.assertTrue(result)
-            mock_print.assert_called_with("\nCancelled 'filepath' operation.")
+def test_cli_initialization(cli):
+    """Test that CLI initializes with correct default values."""
+    assert cli.project_filepath == ''
+    assert cli.user_consent is False
+    assert cli.cmd_history == []
+    assert cli.prompt == '(PAF) '
+    assert cli.ruler == '-'
+    assert "Choose one of the following options" in cli.options
+    assert "Type 'back' or 'cancel'" in cli.options
 
-    def test_handle_cancel_input_with_empty_history(self):
-        """Test cancel handler with empty command history."""
-        self.cli.cmd_history = []
+# Command History Management Tests
 
-        with patch('builtins.print') as mock_print:
-            result = self.cli._handle_cancel_input("back")
-            self.assertTrue(result)
-            mock_print.assert_called_with("\nReturning to main menu.")
 
-    def test_handle_cancel_input_with_non_cancel_commands(self):
-        """Test that non-cancel inputs return False."""
-        test_inputs = ["Y", "N", "1", "2", "3", "invalid", ""]
-        for input_val in test_inputs:
-            result = self.cli._handle_cancel_input(input_val)
-            self.assertFalse(result)
+def test_update_history_basic_functionality(cli):
+    """Test that command history is properly updated."""
+    cli.update_history(cli.cmd_history, "perms")
+    assert cli.cmd_history == ["perms"]
 
-    # Permissions Command Tests
-    @patch('builtins.input', return_value='Y')
-    @patch('builtins.print')
-    def test_do_perms_user_consents(self, mock_print, mock_input):
-        """Test permissions flow when user consents."""
-        self.cli.do_perms("")
+    cli.update_history(cli.cmd_history, "filepath")
+    assert cli.cmd_history == ["perms", "filepath"]
 
-        self.assertTrue(self.cli.user_consent)
-        self.assertEqual(self.cli.cmd_history[0], "perms")
+# Cancel Input Handler Tests
+
+
+def test_handle_cancel_input_with_back(cli):
+    """Test cancel handler with 'back' command."""
+    cli.cmd_history = ["perms"]
+
+    with patch('builtins.print') as mock_print:
+        result = cli._handle_cancel_input("back")
+        assert result is True
+        mock_print.assert_called_with("\nCancelled 'perms' operation.")
+        assert cli.cmd_history == []
+
+
+def test_handle_cancel_input_with_cancel(cli):
+    """Test cancel handler with 'cancel' command."""
+    cli.cmd_history = ["filepath"]
+
+    with patch('builtins.print') as mock_print:
+        result = cli._handle_cancel_input("CANCEL")  # Test case insensitive
+        assert result is True
+        mock_print.assert_called_with("\nCancelled 'filepath' operation.")
+
+
+def test_handle_cancel_input_with_empty_history(cli):
+    """Test cancel handler with empty command history."""
+    cli.cmd_history = []
+
+    with patch('builtins.print') as mock_print:
+        result = cli._handle_cancel_input("back")
+        assert result is True
+        mock_print.assert_called_with("\nReturning to main menu.")
+
+
+def test_handle_cancel_input_with_non_cancel_commands(cli):
+    """Test that non-cancel inputs return False."""
+    test_inputs = ["Y", "N", "1", "2", "3", "invalid", ""]
+    for input_val in test_inputs:
+        result = cli._handle_cancel_input(input_val)
+        assert result is False
+
+# Edge Cases and Error Handling
+
+
+@pytest.mark.parametrize("input_value", ["", "   "])
+def test_empty_input_handling(cli, input_value):
+    """Test handling of empty inputs."""
+    result = cli._handle_cancel_input(input_value)
+    assert result is False
+
+
+@pytest.mark.parametrize("cancel_command", ["  back  ", "\tcancel\n"])
+def test_whitespace_handling_in_cancel(cli, cancel_command):
+    """Test that cancel commands work with extra whitespace."""
+    cli.cmd_history = ["test"]
+    with patch('builtins.print'):
+        result = cli._handle_cancel_input(cancel_command)
+        assert result is True
+
+
+def test_options_text_contains_required_information(cli):
+    """Test that options text contains all required user guidance."""
+    options = cli.options
+
+    # Check for main menu options
+    assert "(1) Permissions" in options
+    assert "(2) Set filepath" in options
+    assert "(3) Begin Artifact Miner" in options
+
+    # Check for cancel instruction
+    assert "back" in options
+    assert "cancel" in options
+    assert "main menu" in options
+
+    # Check for help instruction
+    assert "help" in options
+
+# Permissions Command Tests
+
+
+def test_do_perms_user_consents(cli):
+    """Test permissions flow when user consents."""
+    with patch('builtins.input', return_value='Y'), \
+            patch('builtins.print') as mock_print:
+        cli.do_perms("")
+        assert cli.user_consent is True
+        assert cli.cmd_history[0] == "perms"
         mock_print.assert_any_call(
             "\nThank you for consenting. You may now continue.")
 
-    @patch('builtins.input', return_value='N')
-    @patch('builtins.print')
-    def test_do_perms_user_declines(self, mock_print, mock_input):
-        """Test permissions flow when user declines consent."""
-        result = self.cli.do_perms("")
 
-        self.assertFalse(self.cli.user_consent)
-        self.assertTrue(result)  # Should return True to exit program
+def test_do_perms_user_declines(cli):
+    """Test permissions flow when user declines consent."""
+    with patch('builtins.input', return_value='N'), \
+            patch('builtins.print') as mock_print:
+        result = cli.do_perms("")
+        assert cli.user_consent is False
+        assert result is True  # Should return True to exit program
         mock_print.assert_any_call("Consent not given. Exiting application...")
 
-    @patch('builtins.input', return_value='back')
-    @patch('builtins.print')
-    def test_do_perms_user_cancels(self, mock_print, mock_input):
-        """Test permissions flow when user cancels with 'back'."""
-        result = self.cli.do_perms("")
 
-        self.assertFalse(self.cli.user_consent)
-        self.assertIsNone(result)  # Should return None to go back to menu
-        self.assertEqual(self.cli.cmd_history, [])  # History should be cleared
+def test_do_perms_user_cancels(cli):
+    """Test permissions flow when user cancels with 'back'."""
+    with patch('builtins.input', return_value='back'), \
+            patch('builtins.print') as mock_print:
+        result = cli.do_perms("")
+        assert cli.user_consent is False
+        assert result is None  # Should return None to go back to menu
+        assert cli.cmd_history == []  # History should be cleared
 
-    @patch('builtins.input', side_effect=['invalid', 'another_invalid', 'Y'])
-    @patch('builtins.print')
-    def test_do_perms_handles_invalid_input(self, mock_print, mock_input):
-        """Test that permissions handles invalid input correctly."""
-        self.cli.do_perms("")
 
+def test_do_perms_handles_invalid_input(cli):
+    """Test that permissions handles invalid input correctly."""
+    with patch('builtins.input', side_effect=['invalid', 'another_invalid', 'Y']), \
+            patch('builtins.print') as mock_print:
+        cli.do_perms("")
         # Should eventually succeed after invalid inputs
-        self.assertTrue(self.cli.user_consent)
-
+        assert cli.user_consent is True
         # Check for the actual error message from your CLI code
         mock_print.assert_any_call(
             "Invalid response. Please enter 'Y', 'N', 'back', or 'cancel'.")
 
-    # Filepath Command Tests
-    @patch('builtins.input', return_value='/path/to/project')
-    @patch('builtins.print')
-    def test_do_filepath_valid_path(self, mock_print, mock_input):
-        """Test filepath command with valid input."""
-        self.cli.do_filepath("")
+# Filepath Command Tests
 
-        self.assertEqual(self.cli.project_filepath, '/path/to/project')
-        self.assertEqual(self.cli.cmd_history[0], "filepath")
+
+def test_do_filepath_valid_path(cli):
+    """Test filepath command with valid input."""
+    test_path = '/path/to/project'
+    with patch('builtins.input', return_value=test_path), \
+            patch('builtins.print') as mock_print, \
+            patch('src.classes.cli._is_valid_filepath_to_zip', return_value=0):
+        cli.do_filepath("")
+        assert cli.project_filepath == test_path
+        assert cli.cmd_history[0] == "filepath"
         mock_print.assert_any_call("\nFilepath successfully received")
-        mock_print.assert_any_call('/path/to/project')
+        mock_print.assert_any_call(test_path)
 
-    @patch('builtins.input', return_value='cancel')
-    @patch('builtins.print')
-    def test_do_filepath_user_cancels(self, mock_print, mock_input):
-        """Test filepath command when user cancels."""
-        result = self.cli.do_filepath("")
 
-        self.assertEqual(self.cli.project_filepath, '')  # Should remain empty
-        self.assertIsNone(result)  # Should return None to go back to menu
-        self.assertEqual(self.cli.cmd_history, [])  # History should be cleared
+def test_do_filepath_user_cancels(cli):
+    """Test filepath command when user cancels."""
+    with patch('builtins.input', return_value='cancel'), \
+            patch('builtins.print'):
+        result = cli.do_filepath("")
+        assert cli.project_filepath == ''  # Should remain empty
+        assert result is None  # Should return None to go back to menu
+        assert cli.cmd_history == []  # History should be cleared
 
-    # Begin Command Tests
-    @patch('builtins.print')
-    def test_do_begin_without_consent(self, mock_print):
-        """Test begin command without user consent."""
-        self.cli.do_begin("")
+# Begin Command Tests
 
+
+def test_do_begin_without_consent(cli):
+    """Test begin command without user consent."""
+    with patch('builtins.print') as mock_print:
+        cli.do_begin("")
         mock_print.assert_any_call(
             "\nError: Missing consent. Type perms or 1 to read user permission agreement."
         )
-        self.assertEqual(self.cli.cmd_history[0], "begin")
+        assert cli.cmd_history[0] == "begin"
 
-    # Command Routing Tests
+# Command Routing Tests
 
-    def test_default_command_routing_numeric(self):
-        """Test that numeric commands route to correct functions."""
-        test_cases = [
-            ("1", "do_perms"),
-            ("2", "do_filepath"),
-            ("3", "do_begin")
-        ]
 
-        for command, expected_method in test_cases:
-            with patch.object(self.cli, expected_method) as mock_method:
-                self.cli.default(command)
-                mock_method.assert_called_once_with("")
+@pytest.mark.parametrize("command,expected_method", [
+    ("1", "do_perms"),
+    ("2", "do_filepath"),
+    ("3", "do_begin")
+])
+def test_default_command_routing_numeric(cli, command, expected_method):
+    """Test that numeric commands route to correct functions."""
+    with patch.object(cli, expected_method) as mock_method:
+        cli.default(command)
+        mock_method.assert_called_once_with("")
 
-    def test_default_command_case_insensitive(self):
-        """Test that commands work regardless of case."""
-        with patch.object(self.cli, 'do_perms') as mock_perms:
-            self.cli.default("1")
-            self.cli.default("1".upper())
-            self.assertEqual(mock_perms.call_count, 2)
 
-    @patch('builtins.print')
-    def test_default_handles_unknown_commands(self, mock_print):
-        """Test handling of unknown commands."""
-        unknown_commands = ["unknown", "4", "invalid", "help_me"]
+def test_default_command_case_insensitive(cli):
+    """Test that commands work regardless of case."""
+    with patch.object(cli, 'do_perms') as mock_perms:
+        cli.default("1")
+        cli.default("1".upper())
+        assert mock_perms.call_count == 2
 
+
+def test_default_handles_unknown_commands(cli):
+    """Test handling of unknown commands."""
+    unknown_commands = ["unknown", "4", "invalid", "help_me"]
+    with patch('builtins.print') as mock_print:
         for command in unknown_commands:
-            self.cli.default(command)
+            cli.default(command)
             mock_print.assert_any_call(
                 f"Unknown command: {command}. Type 'help' or '?' for options.")
 
-    # Exit Command Tests
-    @patch('builtins.print')
-    def test_do_exit_functionality(self, mock_print):
-        """Test exit command."""
-        result = self.cli.do_exit("")
+# Exit Command Tests
 
-        self.assertTrue(result)  # Should return True to exit cmdloop
+
+def test_do_exit_functionality(cli):
+    """Test exit command."""
+    with patch('builtins.print') as mock_print:
+        result = cli.do_exit("")
+        assert result is True  # Should return True to exit cmdloop
         mock_print.assert_called_with('Exiting the program...')
 
-    @patch('builtins.input', side_effect=['back', 'cancel'])
-    @patch('builtins.print')
-    def test_cancel_functionality_across_commands(self, mock_print, mock_input):
-        """Test that cancel works consistently across all commands."""
+
+@pytest.mark.parametrize('command', ['back', 'cancel'])
+def test_cancel_functionality_across_commands(cli, command):
+    """Test that cancel works consistently across all commands."""
+    with patch('builtins.input', return_value=command), \
+            patch('builtins.print'):
         # Test cancel from permissions
-        result1 = self.cli.do_perms("")
-        self.assertIsNone(result1)
-        self.assertEqual(self.cli.cmd_history, [])
+        result1 = cli.do_perms("")
+        assert result1 is None
+        assert cli.cmd_history == []
 
         # Test cancel from filepath
-        result2 = self.cli.do_filepath("")
-        self.assertIsNone(result2)
-        self.assertEqual(self.cli.cmd_history, [])
+        result2 = cli.do_filepath("")
+        assert result2 is None
+        assert cli.cmd_history == []
 
     # Edge Cases and Error Handling
     def test_empty_input_handling(self):
@@ -243,8 +315,3 @@ class TestCLI(unittest.TestCase):
 
         # Check for help instruction
         self.assertIn("help", options)
-
-
-if __name__ == '__main__':
-    # Run with verbose output to see individual test results
-    unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## Description

Created logic to warn and prevent a user from entering an incorrect file path. Please take a look at the example below. Also, I changed the tests in test_cli.py to utilize pytest instead of unittest. @eremozdemir Please double-check I am following the same logic with the tests.

```
(PAF) 2
Paste or type the full filepath to your zipped project folder: (or 'back'/'cancel' to return): hello

Error: The provided filepath does not exist. Please try again.

Paste or type the full filepath to your zipped project folder: (or 'back'/'cancel' to return): /workspaces/capstone-project-team-18/src/hello

Error: The provided filepath does not exist. Please try again.

Paste or type the full filepath to your zipped project folder: (or 'back'/'cancel' to return): /workspaces/capstone-project-team-18/src/app.py

Error: The provided filepath does not point to a zip file. Please try again.

Paste or type the full filepath to your zipped project folder: (or 'back'/'cancel' to return): /workspaces/capstone-project-team-18/tests/resources/mac_projects.zip

Filepath successfully received
/workspaces/capstone-project-team-18/tests/resources/mac_projects.zip
```

**Closes:** Closes #133

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation added/updated
- [X] Test added/updated
- [ ] Refactoring
- [ ] Performance improvement

---

## Testing

> Please describe how you tested this PR (both manually and with tests).
> Provide instructions so we can reproduce.

- [X] pytest

---

## Checklist

- [X] GenAI was used in generating the code and I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Any UI changes have been checked to work on desktop, tablet, and/or mobile
