### PR TITLE
Removed redundant print statements in test code

### DIFF
--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -156,7 +156,7 @@ def test_extract_file_reports_recieves_project_with_subfolder(tmp_path, temp_dir
         file_paths=[str(f) for f in temp_directory_with_subfolder["ProjectA"]]
     )
     listReport = extract_file_reports(project_file)
-    print(listReport)
+    # print(listReport)
     assert listReport is not None
     assert len(listReport) == 3 and all(isinstance(report, FileReport)
                                         for report in listReport)

--- a/tests/test_user_report.py
+++ b/tests/test_user_report.py
@@ -1,3 +1,9 @@
+from src.classes.report import UserReport, ProjectReport, FileReport
+from src.classes.statistic import (
+    StatisticIndex, Statistic, StatisticTemplate,
+    UserStatCollection, WeightedSkills, ProjectStatCollection,
+    FileStatCollection
+)
 from datetime import date
 from datetime import datetime
 import unittest
@@ -8,18 +14,13 @@ import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-from src.classes.statistic import (
-    StatisticIndex, Statistic, StatisticTemplate,
-    UserStatCollection, WeightedSkills, ProjectStatCollection, 
-    FileStatCollection
-)
-from src.classes.report import UserReport, ProjectReport, FileReport
-
 # Pytest-style tests for existing functionality
+
 def test_to_user_readable_string():
     idx = StatisticIndex([
         Statistic(UserStatCollection.USER_START_DATE.value, date(2023, 9, 20)),
-        Statistic(UserStatCollection.USER_END_DATE.value,   date(2025, 10, 20)),
+        Statistic(UserStatCollection.USER_END_DATE.value,
+                  date(2025, 10, 20)),
         Statistic(UserStatCollection.USER_SKILLS.value, [
             WeightedSkills("Python", 0.9),
             WeightedSkills("Pandas", 0.7),
@@ -31,6 +32,7 @@ def test_to_user_readable_string():
     assert "You started your first project on 9/20/2023!" in out
     assert "Your latest contribution was on 10/20/2025." in out
     assert "Your skills include: " in out
+
 
 def test_to_user_readable_string_empty():
     idx = StatisticIndex()
@@ -48,40 +50,48 @@ def test_to_user_readable_string_fallback_generic_title_value():
     report = UserReport.from_statistics(idx)
     out = report.to_user_readable_string()
     assert "Custom Unknown Stat: 42" in out
-    
+
  # Unittest-style tests for the new date functionality
+
+
 class TestUserReportDates(unittest.TestCase):
-    
+
     def test_user_dates_from_multiple_projects(self):
         """Test user dates calculation from multiple projects"""
         # Create project 1 (earliest start, middle end)
         project1_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2022, 1, 1)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2022, 6, 15))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2022, 1, 1)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2022, 6, 15))
         ])
         project1 = ProjectReport.from_statistics(project1_stats)
-        
+
         # Create project 2 (middle start, latest end)
         project2_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2022, 3, 1)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2023, 12, 31))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2022, 3, 1)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2023, 12, 31))
         ])
         project2 = ProjectReport.from_statistics(project2_stats)
-        
+
         # Create project 3 (latest start, earliest end)
         project3_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2023, 1, 1)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2022, 3, 15))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2023, 1, 1)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2022, 3, 15))
         ])
         project3 = ProjectReport.from_statistics(project3_stats)
-        
+
         # Create user report
         user = UserReport([project1, project2, project3])
-        
+
         # Test user start date (earliest project start)
         user_start = user.get_value(UserStatCollection.USER_START_DATE.value)
         self.assertEqual(user_start, datetime(2022, 1, 1))
-        
+
         # Test user end date (latest project end)
         user_end = user.get_value(UserStatCollection.USER_END_DATE.value)
         self.assertEqual(user_end, datetime(2023, 12, 31))
@@ -89,28 +99,30 @@ class TestUserReportDates(unittest.TestCase):
     def test_empty_project_list(self):
         """Test that empty project list doesn't crash"""
         user = UserReport([])
-        
+
         # Should not have start or end dates
         user_start = user.get_value(UserStatCollection.USER_START_DATE.value)
         user_end = user.get_value(UserStatCollection.USER_END_DATE.value)
-        
+
         self.assertIsNone(user_start)
         self.assertIsNone(user_end)
 
     def test_single_project(self):
         """Test with only one project"""
         project_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2023, 5, 10)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2023, 8, 20))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2023, 5, 10)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2023, 8, 20))
         ])
         project = ProjectReport.from_statistics(project_stats)
-        
+
         user = UserReport([project])
-        
+
         # Start and end should be the same project's dates
         user_start = user.get_value(UserStatCollection.USER_START_DATE.value)
         user_end = user.get_value(UserStatCollection.USER_END_DATE.value)
-        
+
         self.assertEqual(user_start, datetime(2023, 5, 10))
         self.assertEqual(user_end, datetime(2023, 8, 20))
 
@@ -118,29 +130,33 @@ class TestUserReportDates(unittest.TestCase):
         """Test projects that have None values for dates"""
         # Project with only start date
         project1_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2022, 6, 1))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2022, 6, 1))
         ])
         project1 = ProjectReport.from_statistics(project1_stats)
-        
+
         # Project with only end date
         project2_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2023, 9, 30))
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2023, 9, 30))
         ])
         project2 = ProjectReport.from_statistics(project2_stats)
-        
+
         # Project with both dates
         project3_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2023, 1, 15)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2023, 4, 30))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2023, 1, 15)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2023, 4, 30))
         ])
         project3 = ProjectReport.from_statistics(project3_stats)
-        
+
         user = UserReport([project1, project2, project3])
-        
+
         # Should use earliest start date from available projects
         user_start = user.get_value(UserStatCollection.USER_START_DATE.value)
         self.assertEqual(user_start, datetime(2022, 6, 1))
-        
+
         # Should use latest end date from available projects
         user_end = user.get_value(UserStatCollection.USER_END_DATE.value)
         self.assertEqual(user_end, datetime(2023, 9, 30))
@@ -149,88 +165,99 @@ class TestUserReportDates(unittest.TestCase):
         """Test projects that have no date statistics at all"""
         project_stats = StatisticIndex([])  # No statistics
         project = ProjectReport.from_statistics(project_stats)
-        
+
         user = UserReport([project])
-        
+
         # Should have no dates
         user_start = user.get_value(UserStatCollection.USER_START_DATE.value)
         user_end = user.get_value(UserStatCollection.USER_END_DATE.value)
-        
+
         self.assertIsNone(user_start)
         self.assertIsNone(user_end)
 
     def test_wrong_date_assumptions(self):
         """Test that dates are calculated correctly with assertFalse"""
         project1_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2022, 1, 1)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2022, 6, 15))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2022, 1, 1)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2022, 6, 15))
         ])
         project1 = ProjectReport.from_statistics(project1_stats)
-        
+
         project2_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2023, 1, 1)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2023, 12, 31))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2023, 1, 1)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2023, 12, 31))
         ])
         project2 = ProjectReport.from_statistics(project2_stats)
-        
+
         user = UserReport([project1, project2])
-        
+
         user_start = user.get_value(UserStatCollection.USER_START_DATE.value)
         user_end = user.get_value(UserStatCollection.USER_END_DATE.value)
-        
+
         # Assert wrong assumptions are false
-        self.assertFalse(user_start == datetime(2023, 1, 1))  # Wrong start date
+        self.assertFalse(user_start == datetime(
+            2023, 1, 1))  # Wrong start date
         self.assertFalse(user_end == datetime(2022, 6, 15))   # Wrong end date
         self.assertFalse(user_start == user_end)              # Start != End
-        self.assertFalse(user_start > user_end)               # Start should be before end
+        # Start should be before end
+        self.assertFalse(user_start > user_end)
 
     def test_multiple_projects_complex_dates(self):
         """Test with many projects and complex date patterns"""
         projects = []
-        
+
         # Create 5 projects with various dates
         project_dates = [
             (datetime(2021, 6, 1), datetime(2021, 8, 30)),   # Earliest start
-            (datetime(2022, 1, 15), datetime(2022, 12, 20)),   
+            (datetime(2022, 1, 15), datetime(2022, 12, 20)),
             (datetime(2022, 6, 1), datetime(2024, 1, 31)),   # Latest end
             (datetime(2021, 12, 1), datetime(2022, 3, 15)),
             (datetime(2023, 3, 1), datetime(2023, 11, 30))
         ]
-        
+
         for i, (start_date, end_date) in enumerate(project_dates):
             stats = StatisticIndex([
-                Statistic(ProjectStatCollection.PROJECT_START_DATE.value, start_date),
+                Statistic(
+                    ProjectStatCollection.PROJECT_START_DATE.value, start_date),
                 Statistic(ProjectStatCollection.PROJECT_END_DATE.value, end_date)
             ])
             projects.append(ProjectReport.from_statistics(stats))
-        
+
         user = UserReport(projects)
-        
+
         user_start = user.get_value(UserStatCollection.USER_START_DATE.value)
         user_end = user.get_value(UserStatCollection.USER_END_DATE.value)
-        
+
         # Should be earliest start and latest end
         self.assertEqual(user_start, datetime(2021, 6, 1))
         self.assertEqual(user_end, datetime(2024, 1, 31))
-        
+
         # Assert false conditions
-        self.assertFalse(user_start == datetime(2021, 12, 1))  # Not the second earliest
-        self.assertFalse(user_end == datetime(2023, 11, 30))   # Not the second latest
+        self.assertFalse(user_start == datetime(
+            2021, 12, 1))  # Not the second earliest
+        self.assertFalse(user_end == datetime(
+            2023, 11, 30))   # Not the second latest
 
     def test_user_report_inheritance(self):
         """Test that UserReport properly inherits from BaseReport"""
         project_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2023, 1, 1)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2023, 12, 31))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2023, 1, 1)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2023, 12, 31))
         ])
         project = ProjectReport.from_statistics(project_stats)
-        
+
         user = UserReport([project])
-        
+
         # Test inherited methods work
         self.assertIsNotNone(user.to_dict())
         self.assertIsInstance(user.to_dict(), dict)
-        
+
         # Test that repr doesn't crash
         repr_str = repr(user)
         self.assertIsInstance(repr_str, str)
@@ -241,44 +268,52 @@ class TestUserReportDates(unittest.TestCase):
         # Simulate a user's career progression over time
         # Project 1: College project
         college_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2020, 9, 1)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2020, 12, 15))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2020, 9, 1)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2020, 12, 15))
         ])
         college_project = ProjectReport.from_statistics(college_stats)
-        
+
         # Project 2: Internship project
         internship_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2021, 6, 1)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2021, 8, 31))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2021, 6, 1)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2021, 8, 31))
         ])
         internship_project = ProjectReport.from_statistics(internship_stats)
-        
+
         # Project 3: Full-time work project
         work_stats = StatisticIndex([
-            Statistic(ProjectStatCollection.PROJECT_START_DATE.value, datetime(2022, 1, 3)),
-            Statistic(ProjectStatCollection.PROJECT_END_DATE.value, datetime(2024, 10, 27))
+            Statistic(ProjectStatCollection.PROJECT_START_DATE.value,
+                      datetime(2022, 1, 3)),
+            Statistic(ProjectStatCollection.PROJECT_END_DATE.value,
+                      datetime(2024, 10, 27))
         ])
         work_project = ProjectReport.from_statistics(work_stats)
-        
+
         user = UserReport([college_project, internship_project, work_project])
-        
+
         user_start = user.get_value(UserStatCollection.USER_START_DATE.value)
         user_end = user.get_value(UserStatCollection.USER_END_DATE.value)
-        
+
         # User started in college, most recent work is current
         self.assertEqual(user_start, datetime(2020, 9, 1))
         self.assertEqual(user_end, datetime(2024, 10, 27))
-        
+
         # Verify timeline makes sense
         self.assertTrue(user_start < user_end)
-        self.assertEqual((user_end - user_start).days, (datetime(2024, 10, 27) - datetime(2020, 9, 1)).days)
+        self.assertEqual((user_end - user_start).days,
+                         (datetime(2024, 10, 27) - datetime(2020, 9, 1)).days)
+
 
 if __name__ == '__main__':
     # Run both pytest functions and unittest TestCase
     test_to_user_readable_string()
     test_to_user_readable_string_empty()
     test_to_user_readable_string_fallback_generic_title_value()
-    print("Pytest-style tests passed!")
-    
+    # print("Pytest-style tests passed!")
+
     # Run unittest tests
     unittest.main()


### PR DESCRIPTION
Remove print statements to keep clarity and reduce clutter. Assertions should resolve any questions. **Should be quickly merged to avoid any adverse effects with future scheduled test refactoring**