### PR TITLE
Fixed Issue 187

### DIFF
--- a/src/classes/analyzer.py
+++ b/src/classes/analyzer.py
@@ -249,9 +249,14 @@ class CodeFileAnalyzer(TextFileAnalyzer):
                       FileDomain.CODE),
         ]
         if self._is_git_repo(self.filepath):
-            stats.append(Statistic(FileStatCollection.PERCENTAGE_LINES_COMMITTED.value,
-                                   self._get_file_commit_percentage(self.filepath)))
-            
+
+            file_commit_percentage = self._get_file_commit_percentage(
+                self.filepath)
+
+            if file_commit_percentage is not None:
+                stats.append(Statistic(FileStatCollection.PERCENTAGE_LINES_COMMITTED.value,
+                                       file_commit_percentage))
+
         self.stats.extend(stats)
 
         self._find_coding_language()


### PR DESCRIPTION

## Description

If there were a file in a git repo project that was in the zip, but not in the repo, the program would error out. I fixed this bug and added a test to make sure this would get caught again.


**Closes:** Closes #187 

---

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation added/updated
- [ ] Test added/updated
- [ ] Refactoring
- [ ] Performance improvement

---

## Testing

> Please describe how you tested this PR (both manually and with tests).
> Provide instructions so we can reproduce.

- [X] pytest

---

## Checklist

- [X] GenAI was used in generating the code and I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Any UI changes have been checked to work on desktop, tablet, and/or mobile