### PR TITLE
Create Activity Type Contribution Resume Bullet Point

### DIFF
--- a/src/classes/resume/bullet_point_builder.py
+++ b/src/classes/resume/bullet_point_builder.py
@@ -9,7 +9,8 @@ str bullet points
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List, Protocol, Any
-from src.classes.statistic import ProjectStatCollection, StatisticTemplate, CodingLanguage
+from src.classes.statistic import ProjectStatCollection, StatisticTemplate, CodingLanguage, FileDomain
+from src.utils.data_processing import float_to_percent
 
 
 class ProjectReport(Protocol):
@@ -31,6 +32,40 @@ class BulletRule(ABC):
 class FallBackRule(BulletRule):
     def generate(self, report: ProjectReport) -> List[str]:
         return [f"I contributued and worked on the project {report.project_name}"]
+
+
+class ActivityTypeContributionRule(BulletRule):
+    def generate(self, report: ProjectReport) -> List[str]:
+        """
+        This function will log the activity type contribution
+        project statistic on the project. If a filedomian contribtion
+        was under 5 percent, it will not show. If the bullet point would
+        only list one file domain (like code), it will not show
+
+        Args:
+            report (ProjectReport): The project report to analyze.
+
+        Returns:
+            List[str]: A bullet point for the resume item.
+        """
+
+        activity_type: dict[FileDomain, float] = report.get_value(
+            ProjectStatCollection.ACTIVITY_TYPE_CONTRIBUTIONS.value)
+
+        if activity_type is None or len(activity_type) == 0:
+            return []
+
+        fd_str = []
+
+        for fd, float_percent in activity_type.items():
+            if float_percent > 0.05:
+                fd_str.append(
+                    f"{float_to_percent(float_percent)} on {fd.value}")
+
+        if len(fd_str) <= 1:
+            return []
+
+        return [f"During the project, I split my contributions between following acitivity types: {", ".join(fd_str)}"]
 
 
 class WeightedSkillsRule(BulletRule):
@@ -166,7 +201,8 @@ class BulletPointBuilder:
             CodingLanguageRule(),
             WeightedSkillsRule(),
             GroupProjectRule(),
-            GitCommitPercentage()
+            GitCommitPercentage(),
+            ActivityTypeContributionRule()
         ]
 
         self.fallback: BulletRule = FallBackRule()

--- a/src/classes/statistic.py
+++ b/src/classes/statistic.py
@@ -53,6 +53,7 @@ class CodingLanguage(Enum):
     CSS = ("CSS", [".css", ".scss", ".sass", ".less"])
     SQL = ("SQL", [".sql", ".ddl", ".dml"])
     SHELL = ("Shell", [".sh", ".bash", ".zsh", ".fish"])
+    R = ("R", [".R", ".r"])
 
 # The following are StatisticTemplate classes. A StatisticTemplate is simply a
 # description of a data point. It has a name, description, expected value, and it is either

--- a/src/utils/data_processing.py
+++ b/src/utils/data_processing.py
@@ -33,3 +33,28 @@ def normalize(d: dict[Any, float]) -> None:
 
     for k, v in d.items():
         d[k] = v / total
+
+
+def float_to_percent(f: float) -> str:
+    """
+    Takes a float f in [0,1] and returns
+    a percent that is rounded to one decmial
+    point for text formatting. (e.g. 0.76352 ->
+    76%, 0.01733 -> 2%, 0.0002 -> ~0%)
+
+    Throws error if float is not in [0,1]. Use
+    carefully.
+
+    """
+
+    if not (0 <= f and f <= 1):
+        raise ValueError("Float f not between interval [0,1]")
+
+    f_rounded = round(f * 100)
+
+    percent_str = f"{str(f_rounded)}%"
+
+    if f_rounded == 0:
+        return "~" + percent_str
+
+    return percent_str

--- a/tests/test_resume_builder.py
+++ b/tests/test_resume_builder.py
@@ -1,12 +1,65 @@
-from src.classes.resume.bullet_point_builder import BulletPointBuilder, CodingLanguageRule, WeightedSkillsRule
+from src.classes.resume.bullet_point_builder import BulletPointBuilder, CodingLanguageRule, WeightedSkillsRule, ActivityTypeContributionRule
 from src.classes.statistic import (
     WeightedSkills,
     CodingLanguage,
     Statistic,
     StatisticIndex,
     ProjectStatCollection,
+    FileDomain
 )
 from src.classes.report import ProjectReport
+
+
+def test_activity_type_contribution_bp_expected():
+    """
+    Check expected behavior of ActivityTypeContributionRule
+    """
+
+    ratio = {
+        FileDomain.CODE: 0.12,
+        FileDomain.DESIGN: 0.28,
+        FileDomain.DOCUMENTATION: 0.30,
+        FileDomain.TEST: 0.30
+    }
+
+    report = type("Report", (), {"get_value": lambda self, key: ratio})()
+    bp = ActivityTypeContributionRule().generate(report)[0]  # type: ignore
+
+    assert f"12% on code, 28% on design, 30% on documentation, 30% on test" in bp
+
+
+def test_activity_type_contribution_bp_one_leading():
+    """
+    Check where on file domain dominates ActivityTypeContributionRule
+    """
+
+    ratio = {
+        FileDomain.CODE: 0.9999991,
+        FileDomain.DESIGN: 0.0000009
+    }
+
+    report = type("Report", (), {"get_value": lambda self, key: ratio})()
+    bp = ActivityTypeContributionRule().generate(report)  # type: ignore
+
+    assert len(bp) == 0
+
+
+def test_activity_type_contribution_bp_near_zero():
+    """
+    Check behavior near zero of ActivityTypeContributionRule
+    """
+
+    ratio = {
+        FileDomain.CODE: 0.3999999,
+        FileDomain.TEST: 0.6,
+        FileDomain.DESIGN: 0.0000001
+    }
+
+    report = type("Report", (), {"get_value": lambda self, key: ratio})()
+    bp = ActivityTypeContributionRule().generate(report)[0]  # type: ignore
+
+    assert f"40% on code, 60% on test" in bp
+    assert "design" not in bp
 
 
 def test_coding_language_bp_multiple():


### PR DESCRIPTION
## Description

We have a new project-statistic called activity type contribution. This PR adds this statisitic to the Resume. It looks like the following:
```
backserver : January, 2024 - February, 2024
   - During the project, I split my contributions between following acitivity types: 13% on documentation, 87% on code
```

If the project only had a single file domain, like 100% of contruibutions where code, it will not report on acitivty type contributions.

```
bayesian-scRNAseq-label-transfer : July, 2023 - August, 2023
   - Project was coded using the R language
   - I individually designed, developed, and led the project
   - Accounted for 99.34% of total contribution in the final deliverable
```

Test where added to showcase this logic change.

**Closes:** #286 

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation added/updated
- [ ] Test added/updated
- [ ] Refactoring
- [ ] Performance improvement

---

## Testing

> Please describe how you tested this PR (both manually and with tests).
> Provide instructions so we can reproduce.

- [X] pytest

---

## Checklist

- [X] GenAI was used in generating the code and I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X]  My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Any UI changes have been checked to work on desktop, tablet, and/or mobile
