### PR TITLE
add .gitignore for logs branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# This .gitignore is specific to the logs branch.
+# It will ignore all non-markdown and non-png files
+
+# Ignore everything
+*
+
+# Keep directories so that git can traverse them
+!*/
+
+# Allow markdown and PNGs
+!*.md
+!*.png
+!*.gitignore


### PR DESCRIPTION
Created a `.gitignore` that is specific to the log branch. It only allows us to push markdown & PNG files to avoid accidentally pushing non-log content.