### PR TITLE
Added robust error handling for almebic migration issues

### DIFF
--- a/src/database/utils/db_migrate.py
+++ b/src/database/utils/db_migrate.py
@@ -2,6 +2,10 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from src.utils.errors import AlembicMigrationError
+from src.infrastructure.log.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def run_migrations():
@@ -17,4 +21,15 @@ def run_migrations():
         "script_location", str(ROOT_PATH / 'alembic'))
     alembic_cfg.set_main_option(
         "sqlalchemy.url", "sqlite:///src/database/data.db")
-    command.upgrade(alembic_cfg, "head")
+
+    try:
+        command.upgrade(alembic_cfg, "head")
+    except Exception:
+        print("\n!!! Migrations failed !!!")
+        logger.critical("Alembic migration failed")
+
+        error_msg = "It is likely you added/changed a database-tracked object " \
+            "without handling it in `alembic/versions`. " \
+            "Check `alembic/README.md` for guidance."
+
+        raise AlembicMigrationError(error_msg)

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -13,7 +13,19 @@ class ErrorCode(str, Enum):
     NO_DISCOVERED_PROJECTS = "NO_DISCOVERED_PROJECTS"
     MISSING_CONSENT = "MISSING_CONSENT"
     ANALYSIS_FAILED = "ANALYSIS_FAILED"
+    ALEMBIC_ERROR = "ALMEBIC_ERROR"
+    ALEMBIC_MIGRATION_ERROR = "ALEMBIC_MIGRATION_ERROR"
     UNKNOWN_ERROR = "UNKNOWN_ERROR"
+
+
+class AlembicError(Exception):
+    """Alembic database error"""
+    error_code: ErrorCode = ErrorCode.ALEMBIC_ERROR
+
+
+class AlembicMigrationError(AlembicError):
+    """Alembic Migration database error"""
+    error_code: ErrorCode = ErrorCode.ALEMBIC_MIGRATION_ERROR
 
 
 class ArtifactMinerException(Exception):

--- a/tests/database/test_db_meta.py
+++ b/tests/database/test_db_meta.py
@@ -5,6 +5,7 @@ and also in that we check to see if our fixtures work
 
 from sqlalchemy import inspect
 from sqlalchemy.orm import Session
+from src.database.utils.db_migrate import run_migrations
 
 
 from src.database.models import (
@@ -48,6 +49,18 @@ def test_file_to_project_relationship(temp_db):
         # child rows should reference parent PK via FK
         for fr in project.file_reports:
             assert fr.project_id == project.id
+
+
+def test_migrations(temp_db):
+    """
+    Tests the database migrations. If this errors out, it is
+    very much likely that you added something to a database tracked
+    object (Like adding a statistic to ProjectReport) that you did
+    not handle in `alembic/versions` read the `alembic/README.md`
+    for more information on how to add
+    """
+
+    run_migrations()
 
 
 """


### PR DESCRIPTION
## Description

Often, tests would pass in our PR, then when you ran the app, you would get a vague Almebic failure. This PR adds a specific almebic migration test and if almebic migration errors out, offers a helpful message on what went wrong and how to fix it.

@alextaschuk  Can you fix the underlying alembic bug so that tests will pass?

**Closes:** #405
---

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation added/updated
- [ ] Test added/updated
- [ ] Refactoring
- [ ] Performance improvement

---

## Testing

- [X] pytest

---

## Checklist

- [X] GenAI was used in generating the code and I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Any UI changes have been checked to work on desktop, tablet, and/or mobile
