### PR TITLE
Hotfix: add missing div tag to the homepage

### DIFF
--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -335,6 +335,7 @@ export default function HomePage() {
             </Link>
           </div>
         </section>
+        </div>
       </div>
 
       <UploadProjectModal


### PR DESCRIPTION
There was a missing div in the homepage that was preventing the Electron app from properly rendering. I added the tag.