### PR TITLE
Fix: Persist skeleton UI + HTML/CSS analyzer framework detection

### DIFF
--- a/miner/src/core/analyzer/css_analyzer.py
+++ b/miner/src/core/analyzer/css_analyzer.py
@@ -3,6 +3,7 @@ import tinycss2
 
 from src.core.statistic import Statistic, FileStatCollection
 from src.core.analyzer.specific_code_analyzer import SpecificCodeAnalyzer
+from src.core.analyzer.html_analyzer import _is_external, _is_font_url
 from src.infrastructure.log.logging import get_logger
 
 logger = get_logger(__name__)
@@ -78,7 +79,10 @@ class CSSAnalyzer(SpecificCodeAnalyzer):
                     class_tokens.update(
                         extract_classes_from_prelude(r.prelude))
 
-            imported_packages = list(set(imports))
+            imported_packages = list({
+                url for url in imports
+                if not (_is_external(url) and _is_font_url(url))
+            })
 
         else:
             # ---- Regex fallback (keeps analyzer usable if tinycss2 isn't installed) ----
@@ -106,7 +110,11 @@ class CSSAnalyzer(SpecificCodeAnalyzer):
                 r'@import\s+(?:url\(\s*[\'"]?([^\'")]+)[\'"]?\s*\)|[\'"]([^\'"]+)[\'"])',
                 cleaned
             )
-            imported_packages = list({a or b for a, b in imports})
+            imported_packages = list({
+                url for a, b in imports
+                for url in [a or b]
+                if not (_is_external(url) and _is_font_url(url))
+            })
 
         self.stats.extend([
             Statistic(FileStatCollection.NUMBER_OF_FUNCTIONS.value, rule_count),

--- a/miner/src/core/analyzer/html_analyzer.py
+++ b/miner/src/core/analyzer/html_analyzer.py
@@ -1,3 +1,6 @@
+import re
+from urllib.parse import urlparse
+
 from bs4 import BeautifulSoup
 
 from src.core.statistic import Statistic, FileStatCollection
@@ -7,6 +10,72 @@ from src.infrastructure.log.logging import get_logger
 logger = get_logger(__name__)
 
 
+_FONT_HOSTNAMES = {
+    "fonts.googleapis.com",
+    "fonts.gstatic.com",
+    "use.typekit.net",
+    "use.fontawesome.com",
+    "kit.fontawesome.com",
+}
+
+
+def _is_external(url: str) -> bool:
+    """Return True if the URL points to an external (CDN/remote) resource."""
+    return url.startswith("http://") or url.startswith("https://") or url.startswith("//")
+
+
+def _is_font_url(url: str) -> bool:
+    """Return True if the URL serves fonts rather than a JS/CSS framework."""
+    try:
+        full_url = url if url.startswith("http") else f"https:{url}"
+        hostname = urlparse(full_url).hostname or ""
+        return hostname in _FONT_HOSTNAMES
+    except Exception:
+        return False
+
+
+def _extract_library_name(url: str) -> str:
+    """Extract a clean library name from a CDN URL, falling back to the raw URL."""
+    try:
+        full_url = url if url.startswith("http") else f"https:{url}"
+        parsed = urlparse(full_url)
+        hostname = parsed.hostname or ""
+        path = parsed.path
+
+        # jsdelivr.net/npm/PACKAGE@version/...
+        if "jsdelivr.net" in hostname:
+            m = re.search(r"/(?:npm|gh)/([^/@]+)", path)
+            if m:
+                return m.group(1)
+
+        # cdnjs.cloudflare.com/ajax/libs/PACKAGE/version/...
+        if "cdnjs.cloudflare.com" in hostname:
+            m = re.search(r"/ajax/libs/([^/]+)", path)
+            if m:
+                return m.group(1)
+
+        # unpkg.com/PACKAGE@version/...
+        if "unpkg.com" in hostname:
+            m = re.search(r"/([^/@]+)", path)
+            if m:
+                return m.group(1)
+
+        # googleapis.com/ajax/libs/PACKAGE/version/...
+        if "googleapis.com" in hostname:
+            m = re.search(r"/ajax/libs/([^/]+)", path)
+            if m:
+                return m.group(1)
+
+        # Fall back: strip version and extension from the filename
+        filename = path.rstrip("/").split("/")[-1]
+        name = re.sub(r"(\.min)?\.(js|css)$", "", filename)
+        name = re.sub(r"[-.]?\d+(\.\d+)*$", "", name)
+        return name if name else url
+
+    except Exception:
+        return url
+
+
 class HTMLAnalyzer(SpecificCodeAnalyzer):
     """
     Analyzer for HTML files (.html, .htm).
@@ -14,7 +83,7 @@ class HTMLAnalyzer(SpecificCodeAnalyzer):
     Statistics:
         - NUMBER_OF_FUNCTIONS  (count of <script> blocks, inline + external)
         - NUMBER_OF_CLASSES    (distinct class tokens across elements)
-        - IMPORTED_PACKAGES    (external resources: <script src>, <link href>, <img src>)
+        - IMPORTED_PACKAGES    (CDN-hosted libraries only: <script src>, <link rel="stylesheet" href>)
     """
 
     def _process_not_empty(self) -> None:
@@ -34,25 +103,24 @@ class HTMLAnalyzer(SpecificCodeAnalyzer):
                 if c:
                     class_tokens.add(c)
 
-        # External resources
-        script_srcs = [s["src"] for s in soup.find_all("script", src=True)]
-        link_hrefs = [l["href"] for l in soup.find_all("link", href=True)]
-        img_srcs = [i["src"] for i in soup.find_all("img", src=True)]
-        link_hrefs = [l["href"] for l in soup.find_all("link", href=True)]
-        img_srcs = [i["src"] for i in soup.find_all("img", src=True)]
-        imported_packages = list({*script_srcs, *link_hrefs, *img_srcs})
+        # CDN-hosted scripts only (no fonts)
+        script_libs = [
+            _extract_library_name(s["src"])
+            for s in soup.find_all("script", src=True)
+            if _is_external(s["src"]) and not _is_font_url(s["src"])
+        ]
+
+        # CDN-hosted stylesheets only (rel="stylesheet", no fonts)
+        stylesheet_libs = [
+            _extract_library_name(l["href"])
+            for l in soup.find_all("link", rel="stylesheet", href=True)
+            if _is_external(l["href"]) and not _is_font_url(l["href"])
+        ]
+
+        imported_packages = list(dict.fromkeys(script_libs + stylesheet_libs))
 
         self.stats.extend([
-            Statistic(FileStatCollection.NUMBER_OF_FUNCTIONS.value,
-                      script_count),
-            Statistic(FileStatCollection.NUMBER_OF_CLASSES.value,
-                      len(class_tokens)),
-            Statistic(FileStatCollection.IMPORTED_PACKAGES.value,
-                      imported_packages),
-            Statistic(FileStatCollection.NUMBER_OF_FUNCTIONS.value,
-                      script_count),
-            Statistic(FileStatCollection.NUMBER_OF_CLASSES.value,
-                      len(class_tokens)),
-            Statistic(FileStatCollection.IMPORTED_PACKAGES.value,
-                      imported_packages),
+            Statistic(FileStatCollection.NUMBER_OF_FUNCTIONS.value, script_count),
+            Statistic(FileStatCollection.NUMBER_OF_CLASSES.value, len(class_tokens)),
+            Statistic(FileStatCollection.IMPORTED_PACKAGES.value, imported_packages),
         ])

--- a/miner/tests/analyzer/specific_analyzer/test_html_analyzer.py
+++ b/miner/tests/analyzer/specific_analyzer/test_html_analyzer.py
@@ -9,7 +9,9 @@ def test_html_analyzer_classes_scripts_imports(tmp_path, get_ready_specific_anal
 <html>
   <head>
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <script src="app.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
   </head>
   <body class="container main">
     <div class="container"><button class="btn primary">Click</button></div>
@@ -25,10 +27,41 @@ def test_html_analyzer_classes_scripts_imports(tmp_path, get_ready_specific_anal
     report = analyzer.analyze()
     stats = report.statistics.to_dict()
 
-    assert stats["NUMBER_OF_FUNCTIONS"] == 2
+    assert stats["NUMBER_OF_FUNCTIONS"] == 3  # 2 external + 1 inline
     assert stats["NUMBER_OF_CLASSES"] >= 4
+
     imports = set(stats["IMPORTED_PACKAGES"])
-    assert {"app.js", "style.css", "logo.png"} <= imports
+    # CDN libraries extracted by name
+    assert "jquery" in imports
+    assert "bootstrap" in imports
+    # local files and images must not appear
+    assert "app.js" not in imports
+    assert "style.css" not in imports
+    assert "logo.png" not in imports
+
+
+def test_html_analyzer_local_only(tmp_path, get_ready_specific_analyzer):
+    """Local scripts/stylesheets and images should never appear in IMPORTED_PACKAGES."""
+    html_code = '''
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="/static/main.css">
+    <script src="./js/app.js"></script>
+  </head>
+  <body>
+    <img src="images/banner.jpg" alt="">
+  </body>
+</html>
+'''
+    html_file = tmp_path / "local.html"
+    html_file.write_text(html_code)
+
+    analyzer = get_ready_specific_analyzer(str(tmp_path), "local.html")
+    report = analyzer.analyze()
+    stats = report.statistics.to_dict()
+
+    assert stats["IMPORTED_PACKAGES"] == []
 
 
 def test_html_analyzer_empty_file(tmp_path, get_ready_specific_analyzer):

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -43,8 +43,15 @@ export default function HomePage({ backendReady }: { backendReady: boolean }) {
   const [resumesError, setResumesError] = useState<string | null>(null);
   const [latestResumeId, setLatestResumeId] = useState<number | null>(null);
 
-  const [isProjectAnalysisInProgress, setIsProjectAnalysisInProgress] = useState(false);
-  const [projectCountBeforeUpload, setProjectCountBeforeUpload] = useState(0);
+  const ANALYSIS_KEY = "project_analysis_in_progress";
+  const COUNT_KEY = "project_count_before_upload";
+
+  const [isProjectAnalysisInProgress, setIsProjectAnalysisInProgress] = useState(
+    () => localStorage.getItem(ANALYSIS_KEY) === "true"
+  );
+  const [projectCountBeforeUpload, setProjectCountBeforeUpload] = useState(
+    () => parseInt(localStorage.getItem(COUNT_KEY) ?? "0", 10)
+  );
 
   async function loadProjects() {
     try {
@@ -123,10 +130,14 @@ export default function HomePage({ backendReady }: { backendReady: boolean }) {
 
       if (updatedProjects.length > projectCountBeforeUpload) {
         setIsProjectAnalysisInProgress(false);
+        localStorage.removeItem(ANALYSIS_KEY);
+        localStorage.removeItem(COUNT_KEY);
       }
     } catch (e: any) {
       setError(e?.message ?? "Failed to load projects");
       setIsProjectAnalysisInProgress(false);
+      localStorage.removeItem(ANALYSIS_KEY);
+      localStorage.removeItem(COUNT_KEY);
     }
   }, 3000);
 
@@ -163,9 +174,12 @@ async function handleCreateResume() {
 }
 
 async function handleUploadSuccess() {
-  setProjectCountBeforeUpload(projects.length);
+  const count = projects.length;
+  setProjectCountBeforeUpload(count);
+  localStorage.setItem(COUNT_KEY, String(count));
   setShowUploadModal(false);
   setIsProjectAnalysisInProgress(true);
+  localStorage.setItem(ANALYSIS_KEY, "true");
   await loadProjects();
 }
 

--- a/ui/src/pages/ProjectsPage.tsx
+++ b/ui/src/pages/ProjectsPage.tsx
@@ -21,11 +21,20 @@ type ListProjectsResponse = {
 };
 
 
+const ANALYSIS_KEY = "project_analysis_in_progress";
+const COUNT_KEY = "project_count_before_upload";
+
 export default function ProjectsPage() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [projects, setProjects] = useState<ProjectListItem[]>([]);
+  const [isAnalysisInProgress, setIsAnalysisInProgress] = useState(
+    () => localStorage.getItem(ANALYSIS_KEY) === "true"
+  );
+  const [projectCountBeforeUpload] = useState(
+    () => parseInt(localStorage.getItem(COUNT_KEY) ?? "0", 10)
+  );
 
   async function load() {
     try {
@@ -45,6 +54,29 @@ export default function ProjectsPage() {
   useEffect(() => {
     load();
   }, []);
+
+  useEffect(() => {
+    if (!isAnalysisInProgress) return;
+
+    const interval = setInterval(async () => {
+      try {
+        const res = (await api.getProjects()) as ListProjectsResponse;
+        const updated = Array.isArray(res?.projects) ? res.projects : [];
+        setProjects(updated);
+        if (updated.length > projectCountBeforeUpload) {
+          setIsAnalysisInProgress(false);
+          localStorage.removeItem(ANALYSIS_KEY);
+          localStorage.removeItem(COUNT_KEY);
+        }
+      } catch {
+        setIsAnalysisInProgress(false);
+        localStorage.removeItem(ANALYSIS_KEY);
+        localStorage.removeItem(COUNT_KEY);
+      }
+    }, 3000);
+
+    return () => clearInterval(interval);
+  }, [isAnalysisInProgress, projectCountBeforeUpload]);
 
   return (
     <div style={{ padding: 24, paddingTop: 40, maxWidth: 800, margin: "0 auto" }}>
@@ -84,6 +116,12 @@ export default function ProjectsPage() {
         </button>
       </div>
 
+      {isAnalysisInProgress && (
+        <div style={{ color: "var(--text-muted)", marginBottom: 16, fontSize: 14 }}>
+          Project analysis in progress...
+        </div>
+      )}
+
       {loading && (
         <div
           style={{
@@ -114,7 +152,7 @@ export default function ProjectsPage() {
         </div>
       )}
 
-      {!loading && !error && projects.length === 0 && (
+      {!loading && !error && projects.length === 0 && !isAnalysisInProgress && (
         <div
           style={{
             border: "1px solid var(--border)",
@@ -180,7 +218,12 @@ export default function ProjectsPage() {
               </div>
             </Link>
           ))}
+          {isAnalysisInProgress && <ProjectSkeleton count={3} />}
         </div>
+      )}
+
+      {!loading && !error && projects.length === 0 && isAnalysisInProgress && (
+        <ProjectSkeleton count={3} />
       )}
     </div>
   );


### PR DESCRIPTION
## Description

This PR fixes the skeleton loading UI persistence across navigation and cleans up incorrect framework extraction in the HTML and CSS analyzers.

Specifically, this PR implements:

1. Skeleton Loading UI Persistence
   - `isProjectAnalysisInProgress` and `projectCountBeforeUpload` are now persisted in localStorage so navigating away from the dashboard and returning does not reset the in-progress state
   - Analysis banner and skeleton cards added to the Projects page with the same 3-second polling loop, giving users visibility into ongoing analysis from both the Dashboard and Projects page
   - Polling clears localStorage on completion or error, keeping both pages in sync
2. HTML Analyzer Fix
   - `IMPORTED_PACKAGES` now only includes CDN-hosted (http/https/protocol-relative) URLs — local and relative paths are excluded
   - `<img src>` tags removed from `IMPORTED_PACKAGES` entirely
   - `<link>` tag extraction scoped to `rel="stylesheet"` only
   - CDN URLs are resolved to clean library names (supports jsdelivr, cdnjs, unpkg, and googleapis patterns)
   - Added `_FONT_HOSTNAMES` blocklist (fonts.googleapis.com, fonts.gstatic.com, Font Awesome, Typekit) so font imports are never surfaced as frameworks
   - Removed duplicate stat emissions that caused each statistic to be recorded twice
3. CSS Analyzer Fix
   - Applied the same font blocklist to `@import` rules in the CSS analyzer
   - Filter covers both the `tinycss2` parsing path and the regex fallback path so Google Fonts URLs no longer appear as frameworks regardless of how the CSS is parsed

Closes Issue #567 
Closes Issue #527

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation added/updated
- [x] Test added/updated
- [ ] Refactoring
- [ ] Performance improvement

---

## Testing

- [x] Verified skeleton UI persists when navigating away from the dashboard during project analysis
- [x] Verified skeleton UI and analysis banner appear on the Projects page during analysis
- [x] Verified analysis state clears from both pages once a new project appears
- [x] Verified Google Fonts URLs no longer appear in project frameworks
- [x] Verified local files, relative paths, and images no longer appear in IMPORTED_PACKAGES
- [x] Verified CDN libraries (e.g. Bootstrap, jQuery) are correctly extracted by name
- [x] All HTML analyzer tests passing locally

---

## Checklist

- [x] GenAI was used and code was reviewed
- [x] Code is clean and commented where needed
- [x] No new warnings introduced
- [x] Tests added and passing locally
- [x] Dependencies/config committed for CI compatibility

---

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-03-30 at 03 19 30" src="https://github.com/user-attachments/assets/2ba5d2b3-eb39-4cfe-942d-629df8669c32" />
<img width="1470" height="956" alt="Screenshot 2026-03-30 at 03 19 42" src="https://github.com/user-attachments/assets/f062220b-9151-478a-ac27-2123e770334b" />
<img width="1470" height="956" alt="Screenshot 2026-03-30 at 03 19 49" src="https://github.com/user-attachments/assets/42fad640-91bf-44db-bc78-ac7c37ebdfa1" />
<img width="1470" height="956" alt="Screenshot 2026-03-30 at 03 20 01" src="https://github.com/user-attachments/assets/f389b017-c969-4b7b-b356-ae0eeb909f78" />
