### PR TITLE
Added Language Breakdown Figure To Portfolio

### DIFF
--- a/miner/src/services/portfolio/export_service.py
+++ b/miner/src/services/portfolio/export_service.py
@@ -29,6 +29,34 @@ from src.database.api.CRUD.projects import get_project_report_model_by_name
 from src.utils.errors import KeyNotFoundError
 
 
+_CODING_LANGUAGE_DISPLAY = {
+    "PYTHON": "Python", "JAVASCRIPT": "JavaScript", "TYPESCRIPT": "TypeScript",
+    "JAVA": "Java", "CPP": "C++", "C": "C", "CSHARP": "C#", "PHP": "PHP",
+    "RUBY": "Ruby", "SWIFT": "Swift", "GO": "Go", "RUST": "Rust",
+    "HTML": "HTML", "CSS": "CSS", "SQL": "SQL", "SHELL": "Shell", "R": "R",
+}
+
+
+def _normalize_lang_key(key: str) -> str:
+    """Normalize a language key from any serialization format to display name."""
+    if key.startswith("__enum__:"):
+        return key.rsplit(":", 1)[-1]
+    if "." in key:
+        member = key.rsplit(".", 1)[-1]
+        return _CODING_LANGUAGE_DISPLAY.get(member, member)
+    return key
+
+
+def _aggregate_languages(cards_data: list[dict]) -> dict:
+    """Aggregate language ratios across all cards into display-name keyed totals."""
+    totals: dict = {}
+    for card in cards_data:
+        for key, ratio in (card.get("languages") or {}).items():
+            lang = _normalize_lang_key(str(key))
+            totals[lang] = totals.get(lang, 0.0) + float(ratio)
+    return {k: v for k, v in sorted(totals.items(), key=lambda x: -x[1]) if v > 0}
+
+
 def _json_default(obj: Any) -> Any:
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
@@ -59,9 +87,10 @@ _HTML_TEMPLATE = """\
 {sections_html}
   </section>
 
-  <!-- Figures: contribution map + skill timeline -->
+  <!-- Figures: language breakdown + contribution map + skill timeline -->
   <section id="figures">
     <h2>Figures</h2>
+    <div id="language-breakdown"></div>
     <div id="contribution-map"></div>
     <div id="skill-timeline"></div>
   </section>
@@ -188,6 +217,76 @@ header .portfolio-updated {
 
 .block-list li {
   margin-bottom: 0.2rem;
+}
+
+/* ===== Language breakdown donut ===== */
+.lang-donut-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 28px;
+  flex-wrap: wrap;
+  padding: 8px 0;
+}
+
+.lang-donut-chart {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  flex-shrink: 0;
+}
+
+.lang-donut-circle {
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+}
+
+.lang-donut-inner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 10px;
+  color: #888888;
+  line-height: 1.3;
+}
+
+.lang-donut-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lang-donut-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.lang-donut-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.lang-donut-name {
+  color: #111111;
+  min-width: 80px;
+}
+
+.lang-donut-pct {
+  color: #888888;
 }
 
 /* ===== Figures section ===== */
@@ -1081,16 +1180,22 @@ _FIGURES_JS = """\
   var personal = contrib.personal_timeline  || {};
   var totalTL  = contrib.total_timeline     || {};
   var skillAct = figures.skill_timeline || {};
+  var langBreakdown = figures.language_breakdown || {};
 
   var hasContrib = Object.keys(personal).length > 0 || Object.keys(totalTL).length > 0;
   var hasSkill   = Object.keys(skillAct).length > 0;
+  var hasLangs   = Object.keys(langBreakdown).length > 0;
 
-  if (!hasContrib && !hasSkill) {
+  if (!hasContrib && !hasSkill && !hasLangs) {
     var fig = document.getElementById('figures');
     if (fig) fig.style.display = 'none';
     return;
   }
 
+  if (hasLangs) {
+    var lbEl = document.getElementById('language-breakdown');
+    if (lbEl) buildLanguageDonut(lbEl, langBreakdown);
+  }
   if (hasContrib) {
     var cmEl = document.getElementById('contribution-map');
     if (cmEl) buildContributionMap(cmEl, personal, totalTL);
@@ -1098,6 +1203,85 @@ _FIGURES_JS = """\
   if (hasSkill) {
     var stEl = document.getElementById('skill-timeline');
     if (stEl) buildSkillTimeline(stEl, skillAct);
+  }
+
+  // ==========================================================
+  // Language Breakdown Donut
+  // ==========================================================
+  function buildLanguageDonut(el, langs) {
+    var LANG_COLORS = {
+      'Python':     '#3572A5', 'JavaScript': '#f1e05a', 'TypeScript': '#3178c6',
+      'Java':       '#b07219', 'C++':        '#f34b7d', 'C':          '#555555',
+      'C#':         '#178600', 'PHP':        '#4F5D95', 'Ruby':       '#701516',
+      'Swift':      '#F05138', 'Go':         '#00ADD8', 'Rust':       '#DEA584',
+      'HTML':       '#e34c26', 'CSS':        '#563d7c', 'SQL':        '#e38c00',
+      'Shell':      '#89e051', 'R':          '#198CE7'
+    };
+    var FALLBACK_COLORS = ['#6EC4E8','#ff7c6f','#7cff9a','#ffd06f','#c06fff','#6fecff','#ff6fb8','#a8ff6f'];
+
+    var entries = Object.keys(langs).map(function(k){ return {lang:k, ratio:langs[k]}; });
+    var total = entries.reduce(function(s,e){ return s+e.ratio; }, 0);
+    if (total === 0) return;
+
+    var segments = entries.map(function(e, i) {
+      return {
+        lang:  e.lang,
+        ratio: e.ratio,
+        color: LANG_COLORS[e.lang] || FALLBACK_COLORS[i % FALLBACK_COLORS.length],
+        pct:   (e.ratio / total) * 100
+      };
+    });
+
+    // Build conic-gradient stops
+    var cum = 0;
+    var stops = segments.map(function(s) {
+      var start = cum;
+      cum += s.pct;
+      return s.color + ' ' + start.toFixed(2) + '% ' + cum.toFixed(2) + '%';
+    });
+
+    el.className = 'figure-card';
+
+    var hdr = el.appendChild(document.createElement('div'));
+    hdr.style.cssText = 'margin-bottom:16px;';
+    var hTitle = hdr.appendChild(document.createElement('h3'));
+    hTitle.textContent = 'Language Breakdown';
+    hTitle.style.cssText = 'margin:0;font-size:1rem;font-weight:600;color:#111111;';
+
+    var wrap = el.appendChild(document.createElement('div'));
+    wrap.className = 'lang-donut-wrap';
+
+    // Donut chart
+    var chartDiv = wrap.appendChild(document.createElement('div'));
+    chartDiv.className = 'lang-donut-chart';
+
+    var circle = chartDiv.appendChild(document.createElement('div'));
+    circle.className = 'lang-donut-circle';
+    circle.style.background = 'conic-gradient(' + stops.join(', ') + ')';
+
+    var inner = chartDiv.appendChild(document.createElement('div'));
+    inner.className = 'lang-donut-inner';
+    inner.textContent = entries.length + ' lang' + (entries.length !== 1 ? 's' : '');
+
+    // Legend
+    var legend = wrap.appendChild(document.createElement('div'));
+    legend.className = 'lang-donut-legend';
+    segments.forEach(function(s) {
+      var item = legend.appendChild(document.createElement('div'));
+      item.className = 'lang-donut-legend-item';
+
+      var swatch = item.appendChild(document.createElement('div'));
+      swatch.className = 'lang-donut-swatch';
+      swatch.style.background = s.color;
+
+      var name = item.appendChild(document.createElement('span'));
+      name.className = 'lang-donut-name';
+      name.textContent = s.lang;
+
+      var pct = item.appendChild(document.createElement('span'));
+      pct.className = 'lang-donut-pct';
+      pct.textContent = s.pct.toFixed(1) + '%';
+    });
   }
 
   // ==========================================================
@@ -1700,6 +1884,7 @@ def export_portfolio_static(portfolio_id: int, session: Session) -> bytes:
         "last_updated_at": portfolio.metadata.last_updated_at.isoformat(),
         "project_cards": cards_data,
         "figures": {
+            "language_breakdown": _aggregate_languages(cards_data),
             "contribution": {
                 "personal_timeline": personal_timeline,
                 "total_timeline": total_timeline,

--- a/ui/src/components/LanguageDonut.tsx
+++ b/ui/src/components/LanguageDonut.tsx
@@ -1,0 +1,96 @@
+// GitHub Linguist-style colors per language
+export const LANG_COLOR_MAP: Record<string, string> = {
+  Python:     "#3572A5",
+  JavaScript: "#f1e05a",
+  TypeScript: "#3178c6",
+  Java:       "#b07219",
+  "C++":      "#f34b7d",
+  C:          "#555555",
+  "C#":       "#178600",
+  PHP:        "#4F5D95",
+  Ruby:       "#701516",
+  Swift:      "#F05138",
+  Go:         "#00ADD8",
+  Rust:       "#DEA584",
+  HTML:       "#e34c26",
+  CSS:        "#563d7c",
+  SQL:        "#e38c00",
+  Shell:      "#89e051",
+  R:          "#198CE7",
+};
+
+export const LANG_FALLBACK_COLORS = [
+  "#6EC4E8", "#ff7c6f", "#7cff9a", "#ffd06f",
+  "#c06fff", "#6fecff", "#ff6fb8", "#a8ff6f",
+];
+
+export function LanguageDonut({ langs }: { langs: Array<{ lang: string; ratio: number }> }) {
+  const total = langs.reduce((s, d) => s + d.ratio, 0);
+  if (total === 0) return null;
+
+  const segments = langs.map((d, i) => ({
+    ...d,
+    color: LANG_COLOR_MAP[d.lang] ?? LANG_FALLBACK_COLORS[i % LANG_FALLBACK_COLORS.length],
+    pct: (d.ratio / total) * 100,
+  }));
+
+  let cum = 0;
+  const stops = segments.map((s) => {
+    const start = cum;
+    cum += s.pct;
+    return `${s.color} ${start.toFixed(2)}% ${cum.toFixed(2)}%`;
+  });
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 28, flexWrap: "wrap" }}>
+      <div style={{ position: "relative", width: 140, height: 140, flexShrink: 0 }}>
+        <div
+          style={{
+            width: 140,
+            height: 140,
+            borderRadius: "50%",
+            background: `conic-gradient(${stops.join(", ")})`,
+          }}
+        />
+        {/* Inner circle cutout for donut effect */}
+        <div
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: 72,
+            height: 72,
+            borderRadius: "50%",
+            background: "var(--bg-surface)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <span style={{ fontSize: 10, color: "var(--text-secondary)", textAlign: "center", lineHeight: 1.3 }}>
+            {langs.length} lang{langs.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {segments.map((s) => (
+          <div key={s.lang} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13 }}>
+            <div
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: 2,
+                background: s.color,
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ color: "var(--text-primary)", minWidth: 80 }}>{s.lang}</span>
+            <span style={{ color: "var(--text-muted)" }}>{s.pct.toFixed(1)}%</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/PortfolioEditPage.tsx
+++ b/ui/src/pages/PortfolioEditPage.tsx
@@ -5,6 +5,7 @@ import TextBlockEditor from "../components/blocks/TextBlockEditor";
 import TextListBlockEditor from "../components/blocks/TextListBlockEditor";
 import ContributionMap from "../components/ContributionMap";
 import SkillTimelineGraph from "../components/SkillTimelineGraph";
+import { LanguageDonut } from "../components/LanguageDonut";
 
 // ---- Types ----------------------------------------------------------------
 
@@ -38,6 +39,7 @@ type PortfolioCard = {
   tags: string[];
   skills: string[];
   frameworks: string[];
+  languages?: Record<string, number>;
   is_showcase: boolean;
   collaboration_role?: string;
   title_override?: string | null;
@@ -63,6 +65,38 @@ type BlockEditEntry = {
 };
 
 // ---- Helpers ---------------------------------------------------------------
+
+const CODING_LANGUAGE_DISPLAY: Record<string, string> = {
+  PYTHON: "Python", JAVASCRIPT: "JavaScript", TYPESCRIPT: "TypeScript",
+  JAVA: "Java", CPP: "C++", C: "C", CSHARP: "C#", PHP: "PHP",
+  RUBY: "Ruby", SWIFT: "Swift", GO: "Go", RUST: "Rust",
+  HTML: "HTML", CSS: "CSS", SQL: "SQL", SHELL: "Shell", R: "R",
+};
+
+function parseCardLanguageName(key: string): string {
+  if (key.startsWith("__enum__:")) return key.split(":").pop() ?? key;
+  const dotIdx = key.lastIndexOf(".");
+  if (dotIdx >= 0) {
+    const member = key.slice(dotIdx + 1);
+    return CODING_LANGUAGE_DISPLAY[member] ?? member;
+  }
+  return key;
+}
+
+function aggregatePortfolioLanguages(cards: PortfolioCard[]): Array<{ lang: string; ratio: number }> {
+  const totals: Record<string, number> = {};
+  for (const card of cards) {
+    if (!card.languages) continue;
+    for (const [key, ratio] of Object.entries(card.languages)) {
+      const lang = parseCardLanguageName(key);
+      totals[lang] = (totals[lang] ?? 0) + ratio;
+    }
+  }
+  return Object.entries(totals)
+    .map(([lang, ratio]) => ({ lang, ratio }))
+    .filter(({ ratio }) => ratio > 0)
+    .sort((a, b) => b.ratio - a.ratio);
+}
 
 function formatDate(value?: string) {
   if (!value) return "—";
@@ -277,6 +311,7 @@ export default function PortfolioEditPage() {
     endDate: null,
   });
   const [contributionLoading, setContributionLoading] = useState(false);
+  const [languageBreakdown, setLanguageBreakdown] = useState<Array<{ lang: string; ratio: number }>>([]);
 
   // ---- Load ----------------------------------------------------------------
 
@@ -300,6 +335,7 @@ export default function PortfolioEditPage() {
       setTitleDraft(data.title);
       initCardEdits(data.project_cards);
       initBlockEdits(data.sections);
+      setLanguageBreakdown(aggregatePortfolioLanguages(data.project_cards));
 
       try {
         setContributionLoading(true);
@@ -1042,9 +1078,24 @@ export default function PortfolioEditPage() {
       )}
 
       {/* ---- Figures ---- */}
-      {(contributionLoading || contributionData || Object.keys(skillTimelineData).length > 0) && (
+      {(contributionLoading || contributionData || Object.keys(skillTimelineData).length > 0 || languageBreakdown.length > 0) && (
         <div style={{ marginTop: 40 }}>
           <h2 style={{ marginBottom: 16 }}>Figures</h2>
+
+          {languageBreakdown.length > 0 && (
+            <div
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: 16,
+                padding: 20,
+                background: "var(--bg-surface)",
+                marginBottom: 16,
+              }}
+            >
+              <h3 style={{ marginTop: 0, marginBottom: 16, fontSize: 15, fontWeight: 600 }}>Language Breakdown</h3>
+              <LanguageDonut langs={languageBreakdown} />
+            </div>
+          )}
 
           {contributionLoading && (
             <div style={{ color: "var(--text-muted)", fontSize: 13 }}>

--- a/ui/src/pages/ProjectDetailsPage.tsx
+++ b/ui/src/pages/ProjectDetailsPage.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { api } from "../api/apiClient";
+import { LANG_COLOR_MAP, LANG_FALLBACK_COLORS, LanguageDonut } from "../components/LanguageDonut";
 
 type WeightedSkill = { name?: string; skill?: string; weight?: number } | string;
 
@@ -97,30 +98,6 @@ function parseCommitDistribution(value: unknown): Array<{ type: string; pct: num
     .sort((a, b) => b.pct - a.pct);
 }
 
-// GitHub Linguist-style colors per language
-const LANG_COLOR_MAP: Record<string, string> = {
-  Python:     "#3572A5",
-  JavaScript: "#f1e05a",
-  TypeScript: "#3178c6",
-  Java:       "#b07219",
-  "C++":      "#f34b7d",
-  C:          "#555555",
-  "C#":       "#178600",
-  PHP:        "#4F5D95",
-  Ruby:       "#701516",
-  Swift:      "#F05138",
-  Go:         "#00ADD8",
-  Rust:       "#DEA584",
-  HTML:       "#e34c26",
-  CSS:        "#563d7c",
-  SQL:        "#e38c00",
-  Shell:      "#89e051",
-  R:          "#198CE7",
-};
-const LANG_FALLBACK_COLORS = [
-  "#6EC4E8", "#ff7c6f", "#7cff9a", "#ffd06f",
-  "#c06fff", "#6fecff", "#ff6fb8", "#a8ff6f",
-];
 
 const COMMIT_COLORS: Record<string, string> = {
   feature: "#6EC4E8",
@@ -285,76 +262,6 @@ function ProgressBar({
   );
 }
 
-function LanguageDonut({ langs }: { langs: Array<{ lang: string; ratio: number }> }) {
-  const total = langs.reduce((s, d) => s + d.ratio, 0);
-  if (total === 0) return null;
-
-  const segments = langs.map((d, i) => ({
-    ...d,
-    color: LANG_COLOR_MAP[d.lang] ?? LANG_FALLBACK_COLORS[i % LANG_FALLBACK_COLORS.length],
-    pct: (d.ratio / total) * 100,
-  }));
-
-  let cum = 0;
-  const stops = segments.map((s) => {
-    const start = cum;
-    cum += s.pct;
-    return `${s.color} ${start.toFixed(2)}% ${cum.toFixed(2)}%`;
-  });
-
-  return (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 28, flexWrap: "wrap" }}>
-      <div style={{ position: "relative", width: 140, height: 140, flexShrink: 0 }}>
-        <div
-          style={{
-            width: 140,
-            height: 140,
-            borderRadius: "50%",
-            background: `conic-gradient(${stops.join(", ")})`,
-          }}
-        />
-        {/* Inner circle cutout for donut effect */}
-        <div
-          style={{
-            position: "absolute",
-            top: "50%",
-            left: "50%",
-            transform: "translate(-50%, -50%)",
-            width: 72,
-            height: 72,
-            borderRadius: "50%",
-            background: "var(--bg-surface)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <span style={{ fontSize: 10, color: "var(--text-secondary)", textAlign: "center", lineHeight: 1.3 }}>
-            {langs.length} lang{langs.length !== 1 ? "s" : ""}
-          </span>
-        </div>
-      </div>
-
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {segments.map((s) => (
-          <div key={s.lang} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13 }}>
-            <div
-              style={{
-                width: 10,
-                height: 10,
-                borderRadius: 2,
-                background: s.color,
-                flexShrink: 0,
-              }}
-            />
-            <span style={{ color: "var(--text-primary)", minWidth: 80 }}>{s.lang}</span>
-            <span style={{ color: "var(--text-muted)" }}>{s.pct.toFixed(1)}%</span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
 
 function CommitTypeChart({ items }: { items: Array<{ type: string; pct: number }> }) {
   return (


### PR DESCRIPTION
## Description

Previously, the project view page showcased the language breakdown, but we didn't have it in the portfolio or the web download. This PR changes that.
<img width="1424" height="766" alt="Screenshot 2026-04-05 at 2 01 58 PM" src="https://github.com/user-attachments/assets/8f27e525-29d3-4da1-94c2-d025dc9af8c0" />
<img width="1106" height="640" alt="Screenshot 2026-04-05 at 2 01 39 PM" src="https://github.com/user-attachments/assets/b7e364a2-899f-4b1c-b1c5-60df1f5c6d9a" />

**Closes:** # (issue number)

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation added/updated
- [ ] Test added/updated
- [ ] Refactoring
- [ ] Performance improvement

---

## Testing

> Please describe how you tested this PR (both manually and with tests).
> Provide instructions so we can reproduce.

- [X] pytest
- [X] vitest

---

## Checklist

- [X] GenAI was used in generating the code and I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Any UI changes have been checked to work on desktop, tablet, and/or mobile
